### PR TITLE
handle sass error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,10 @@ gulp.task('scripts', function() {
 
 gulp.task('sass', function(done) {
     gulp.src(paths.sass)
-        .pipe(sass({ errLogToConsole: true }))
+        .pipe(
+          sass({ errLogToConsole: true })
+          .on('error', console.log)
+        )
         .pipe(stripCssComments())
         .pipe(autoprefixer({
             browsers: ['last 2 versions'],


### PR DESCRIPTION
i had some error trying to run `gulp sass` task but error from sass wsn't being handled. Now it is.

From this:
```sh
[22:50:54] Starting 'sass'...

events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: bower_components/material-design-lite/src/_variables.scss
  311:20  
    at options.error (/Users/Denis/git/ionic-material-design-lite/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:276:32)
```

To this:

```sh
$ gulp sass
[22:47:01] Starting 'sass'...
{ [Error: bower_components/material-design-lite/src/_variables.scss
  311:20  ]
  message: 'bower_components/material-design-lite/src/_variables.scss\n  311:20  ',
  column: 20,
  line: 311,
  file: 'bower_components/material-design-lite/src/_variables.scss',
  status: 1,
  messageFormatted: '\u001b[4mbower_components/material-design-lite/src/_variables.scss\u001b[24m\n\u001b[90m  311:20\u001b[39m  ',
  name: 'Error',
  stack: 'Error: bower_components/material-design-lite/src/_variables.scss\n  311:20  \n    at options.error (/Users/Denis/git/ionic-material-design-lite/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:276:32)',
  showStack: false,
  showProperties: true,
  plugin: 'gulp-sass' }
```

btw, i link an issue i'm having while running `gulp sass` task #32